### PR TITLE
Add utilities and API client for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ yarn-error.log
 *.tfstate
 *.tfstate.backup
 *.tfvars
+# Allow frontend library code
+!frontend/src/lib/
+!frontend/src/lib/**

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # Careernus
-Plateforme de recrutement intelligente
+
+Careernus est une plateforme de recherche d'emploi et d'optimisation de CV alimentée par l'IA. Elle permet :
+
+- l'analyse de CV (PDF ou DOCX) et de descriptions de poste
+- l'obtention d'un score de correspondance détaillé
+- la génération de CV adaptés aux ATS et de lettres de motivation
+- le suivi de l'historique des candidatures
+
+## Démarrage rapide
+
+La stack comprend un backend **FastAPI** et un frontend **Next.js**. Un environnement de développement complet est disponible via Docker Compose :
+
+```bash
+# Lancer tous les services
+docker-compose up --build
+```
+
+Par défaut :
+- l'API est accessible sur `http://localhost:8000`
+- l'application web est disponible sur `http://localhost:3000`
+
+Créez un fichier `.env` à la racine du dossier `backend` pour surcharger la configuration (clé secrète, URL de base de données, etc.).
+
+## Structure du dépôt
+
+- `backend/` : API FastAPI, modèles SQLAlchemy et services d'analyse de CV
+- `frontend/` : interface utilisateur Next.js avec Tailwind CSS
+- `docker-compose.yml` : orchestrateur pour la base de données PostgreSQL, le backend et le frontend
+
+Ce projet est conçu pour être extensible : vous pouvez facilement ajouter de nouveaux services ou intégrer des fournisseurs d'IA externes.

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -1,0 +1,60 @@
+import axios from "axios";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+const api = axios.create({
+  baseURL: `${API_BASE_URL}/api`,
+});
+
+api.interceptors.request.use((config) => {
+  if (typeof window !== "undefined") {
+    const token = localStorage.getItem("token");
+    if (token) {
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+export const authService = {
+  async login(email: string, password: string) {
+    const formData = new URLSearchParams();
+    formData.append("username", email);
+    formData.append("password", password);
+    const { data } = await api.post("/auth/token", formData);
+    return data;
+  },
+  async register(email: string, password: string, fullName: string) {
+    const { data } = await api.post("/auth/register", {
+      email,
+      password,
+      full_name: fullName,
+    });
+    return data;
+  },
+  async getCurrentUser() {
+    const { data } = await api.get("/auth/me");
+    return data;
+  },
+};
+
+export const resumeService = {
+  async uploadResume(file: File, title: string) {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("title", title);
+    const { data } = await api.post("/resumes/upload", formData);
+    return data;
+  },
+  async getResume(id: number) {
+    const { data } = await api.get(`/resumes/${id}`);
+    return data;
+  },
+  async listResumes() {
+    const { data } = await api.get("/resumes");
+    return data;
+  },
+};
+
+export default api;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- add `cn` utility for merging class names
- implement Axios-based API client with auth and resume services
- document project setup and structure
- allow tracking `frontend/src/lib` in `.gitignore`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af26c56d483338835502a20f7ff92