### PR TITLE
Add missing jose JWT imports

### DIFF
--- a/backend/src/api/endpoints/auth.py
+++ b/backend/src/api/endpoints/auth.py
@@ -3,6 +3,7 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from datetime import timedelta
 from typing import Any, Optional
+from jose import JWTError, jwt
 
 from ...database import get_db
 from ...models.user import User


### PR DESCRIPTION
## Summary
- include `JWTError` and `jwt` from `jose` in auth API endpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684af97dcf7483338383f26feb5b55d4