### PR TITLE
Remove unused imports from resume_analyzer

### DIFF
--- a/backend/src/services/resume_analyzer.py
+++ b/backend/src/services/resume_analyzer.py
@@ -1,7 +1,5 @@
 from typing import Dict, Any, List, Optional
 import re
-import json
-import os
 from ..schemas.resume import ResumeAnalysisResponse
 
 class ResumeAnalyzer:


### PR DESCRIPTION
## Summary
- clean unused imports in `resume_analyzer.py`

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684af981fb94833388f06a05c4f997b5